### PR TITLE
Remove `center=true` from `sphere`

### DIFF
--- a/lib/bezier.scad
+++ b/lib/bezier.scad
@@ -311,7 +311,7 @@ module bezier(controlPoints, samples=10, controlPointSize=1) {
 module showBezierControlPoints(controlPoints, controlPointSize=1) {
   if (controlPointSize != 0) {
     for (cp = controlPoints) {
-      %color("red", 1.0) translate([cp[0], cp[1], len(cp) == 3 ? cp[2] : 0]) sphere(controlPointSize, center=true);
+      %color("red", 1.0) translate([cp[0], cp[1], len(cp) == 3 ? cp[2] : 0]) sphere(controlPointSize);
     }
   }
 }


### PR DESCRIPTION
`center` isn't a named param of `sphere` and this causes an error under OpenSCAD 2022.06.